### PR TITLE
Misuv 3880 fix tax year summary date displaying incorrectly

### DIFF
--- a/app/models/calculation/CalculationResponseModel.scala
+++ b/app/models/calculation/CalculationResponseModel.scala
@@ -18,6 +18,8 @@ package models.calculation
 
 import play.api.libs.json._
 
+import java.time.LocalDate
+
 sealed trait LiabilityCalculationResponseModel
 
 case class LiabilityCalculationError(status: Int, message: String) extends LiabilityCalculationResponseModel
@@ -37,7 +39,12 @@ object CalculationResponseModel {
   implicit val format: OFormat[CalculationResponseModel] = Json.format[CalculationResponseModel]
 }
 
-case class Metadata(calculationTimestamp: Option[String], crystallised: Option[Boolean], calculationReason: Option[String])
+case class Metadata(
+                     calculationTimestamp: Option[String],
+                     crystallised: Option[Boolean],
+                     calculationReason: Option[String],
+                     periodFrom: Option[LocalDate],
+                     periodTo: Option[LocalDate])
 
 object Metadata {
   implicit val format: OFormat[Metadata] = Json.format[Metadata]

--- a/it/assets/GetCalculationDetailsConstants.scala
+++ b/it/assets/GetCalculationDetailsConstants.scala
@@ -19,6 +19,8 @@ package assets
 import models.calculation._
 import models.calculation.taxcalculation._
 
+import java.time.LocalDate
+
 object GetCalculationDetailsConstants {
 
   val successModelFull = CalculationResponseModel(
@@ -251,7 +253,9 @@ object GetCalculationDetailsConstants {
     metadata = Metadata(
       calculationTimestamp = Some("2019-02-15T09:35:15.094Z"),
       crystallised = Some(true),
-      calculationReason = Some("customerRequest"))
+      calculationReason = Some("customerRequest"),
+      periodFrom = Some(LocalDate.of(2019,1,1)),
+      periodTo = Some(LocalDate.of(2020,1,1)))
   )
 
   val successCalcDetailsExpectedJsonFull =
@@ -286,7 +290,9 @@ object GetCalculationDetailsConstants {
        |  "metadata" : {
        |    "calculationTimestamp" : "2019-02-15T09:35:15.094Z",
        |    "crystallised" : true,
-       |    "calculationReason": "customerRequest"
+       |    "calculationReason": "customerRequest",
+       |    "periodFrom": "2019-01-01",
+       |    "periodTo": "2020-01-01"
        |  },
        |  "calculation" : {
        |    "allowancesAndDeductions" : {

--- a/test/models/calculation/CalculationResponseModelModelSpec.scala
+++ b/test/models/calculation/CalculationResponseModelModelSpec.scala
@@ -21,10 +21,13 @@ import play.api.libs.json._
 import testConstants.GetCalculationDetailsConstants.{successCalcDetailsExpectedJsonFull, successModelFull}
 import testUtils.TestSuite
 
+import java.time.LocalDate
+
 class CalculationResponseModelModelSpec extends TestSuite {
 
   "LastTaxCalculationResponseMode model" when {
     "successful successModelMinimal" should {
+      val taxYear = 2020
       val successModelMinimal = CalculationResponseModel(
         inputs = Inputs(personalInformation = PersonalInformation(taxRegime = "UK", class2VoluntaryContributions = None)),
         messages = None,
@@ -32,7 +35,9 @@ class CalculationResponseModelModelSpec extends TestSuite {
         metadata = Metadata(
           calculationTimestamp = Some("2019-02-15T09:35:15.094Z"),
           crystallised = Some(true),
-          calculationReason = Some("customerRequest"))
+          calculationReason = Some("customerRequest"),
+          periodFrom = Some(LocalDate.of(taxYear-1,1,1)),
+          periodTo = Some(LocalDate.of(taxYear,1,1)))
       )
       val expectedJson = s"""
                             |{
@@ -40,7 +45,9 @@ class CalculationResponseModelModelSpec extends TestSuite {
                             |  "metadata" : {
                             |    "calculationTimestamp" : "2019-02-15T09:35:15.094Z",
                             |    "crystallised" : true,
-                            |    "calculationReason": "customerRequest"
+                            |    "calculationReason": "customerRequest",
+                            |    "periodFrom": "2019-01-01",
+                            |    "periodTo": "2020-01-01"
                             |  }
                             |}
                             |""".stripMargin.trim

--- a/test/resources/liabilityResponsePruned.json
+++ b/test/resources/liabilityResponsePruned.json
@@ -28,7 +28,9 @@
   "metadata" : {
     "calculationTimestamp" : "2019-02-15T09:35:15.094Z",
     "crystallised" : true,
-    "calculationReason": "customerRequest"
+    "calculationReason": "customerRequest",
+    "periodFrom": "2019-01-01",
+    "periodTo": "2020-01-01"
   },
   "calculation" : {
     "allowancesAndDeductions" : {

--- a/test/testConstants/GetCalculationDetailsConstants.scala
+++ b/test/testConstants/GetCalculationDetailsConstants.scala
@@ -19,6 +19,7 @@ package testConstants
 import models.calculation._
 import models.calculation.taxcalculation._
 
+import java.time.LocalDate
 import scala.io.Source
 
 object GetCalculationDetailsConstants {
@@ -253,7 +254,9 @@ object GetCalculationDetailsConstants {
     metadata = Metadata(
       calculationTimestamp = Some("2019-02-15T09:35:15.094Z"),
       crystallised = Some(true),
-      calculationReason = Some("customerRequest"))
+      calculationReason = Some("customerRequest"),
+      periodFrom = Some(LocalDate.of(2019,1,1)),
+      periodTo = Some(LocalDate.of(2020,1,1)))
   )
 
   val source = Source.fromURL(getClass.getResource("/liabilityResponsePruned.json"))


### PR DESCRIPTION
### Description
The CalculationResponseModel has been updated with "periodFrom" and "periodTo" in its Metadata. 
The calculation period was not available in the response, Hence the change.

Add a link to the relevant story in Jira
[MISUV-3880 Fix Tax Year Summary Date Displaying Incorrectly](https://jira.tools.tax.service.gov.uk/browse/MISUV-3880)

### Checklist PR Reviewer
##### Before Reviewing
- [ ]  Have you pulled the branch down?
- [ ]  Have you assigned yourself to the PR?
- [ ]  Have you moved the task to “in review” on JIRA?
- [ ]  Have you checked to ensure all dependencies are up to date?
- [ ]  Have you checked to ensure its been rebased against the current version of main?

##### Whilst Reviewing
- [ ]  Have you run the tests?
- [ ]  Have you run the journey tests?
- [ ]  Have you looked at the JIRA story to make sure all Acceptance Criteria has been met?

##### After Reviewing
- [ ]  Have you checked for merge conflicts or any changes in the current main that may affect the current pull request? i.e. does it need another rebase?
- [ ]  Have you checked to make sure there are no builds in the pipeline before you merge?
- [ ]  Have you moved the task to “in pipeline” on Jira?

### Checklist PR Raiser
##### Before creating PR
- [ ]  Have you run the tests?
- [ ]  Have you run the journey tests? (where applicable)
- [ ]  Have you addressed warnings where appropriate?
- [ ]  Have you rebased against the current version of main?
- [ ]  Have you checked code coverage isn’t lower than previously?

##### After PRs been raised
- [ ]  Have you checked the PR Builder passes?
